### PR TITLE
Fix VDOP: use sin(lat) for Up basis vector z-component

### DIFF
--- a/src/navigation/dop.rs
+++ b/src/navigation/dop.rs
@@ -29,7 +29,7 @@ impl DilutionOfPrecision {
             lat_rad.cos() * lon_rad.sin(),
             0.0_f64,
             lat_rad.cos(),
-            lon_rad.sin(),
+            lat_rad.sin(),
         );
 
         let q_3 = Matrix3::<f64>::new(


### PR DESCRIPTION
## What

In `DilutionOfPrecision::q_enu` (the ECEF→ENU rotation matrix), the `(2,2)` element was coded as `lon_rad.sin()` instead of `lat_rad.sin()`.

```diff
             0.0_f64,
             lat_rad.cos(),
-            lon_rad.sin(),
+            lat_rad.sin(),
         );
```

## Why

The matrix `r` is built so that its columns are the East / North / Up basis vectors (so `q_enu = rᵀ · q_3 · r = R · Q_ecef · Rᵀ`). The "Up" basis vector in ECEF is:

```
[ cos(lat)cos(lon), cos(lat)sin(lon), sin(lat) ]
```

so its z-component must be `sin(lat)`. With the wrong `sin(lon)`, the Up basis vector was corrupted, and **VDOP** — read from `q_enu[(2,2)]` — was computed against a wrong vertical direction, producing impossible values such as `0.5`.

**HDOP** reads the East/North columns (`q_enu[(0,0)] + q_enu[(1,1)]`), which were correct, so it was unaffected.

## Notes

- Builds cleanly (`cargo build`); the only warnings are pre-existing dead-code notices.
- No test changes required — no existing tests asserted the buggy DOP values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)