### PR TITLE
Add elevation-dependent measurement weighting

### DIFF
--- a/src/candidate/ppp.rs
+++ b/src/candidate/ppp.rs
@@ -113,8 +113,6 @@ impl Candidate {
         bias_m += self.tropod;
         contribution.tropo_bias = Some(self.tropod);
 
-        vec.sigma = 1.0; // TODO
-
         let pr = range_m - rho - bias_m;
 
         let cp = cp.map(|cp| cp - rho - bias_m);
@@ -123,13 +121,19 @@ impl Candidate {
             return Err(Error::MissingPhaseRange)?;
         }
 
+        // Measurement weighting: row #1 is code (or phase in single-row PPP),
+        // row #2 is phase. Deviations follow the configured elevation model.
         if two_rows {
             vec.row_1 = pr;
             vec.row_2 = cp.unwrap_or_default();
+            vec.sigma_1 = cfg.solver.code_sigma_m(Some(elev_deg));
+            vec.sigma_2 = cfg.solver.phase_sigma_m(Some(elev_deg));
         } else if cfg.method == Method::PPP {
             vec.row_1 = cp.unwrap_or_default();
+            vec.sigma_1 = cfg.solver.phase_sigma_m(Some(elev_deg));
         } else {
             vec.row_1 = pr;
+            vec.sigma_1 = cfg.solver.code_sigma_m(Some(elev_deg));
         }
 
         Ok(vec)

--- a/src/candidate/rtk.rs
+++ b/src/candidate/rtk.rs
@@ -63,6 +63,29 @@ impl Candidate {
             }
         }
 
+        // Measurement weighting, keyed off this satellite's elevation.
+        // NOTE: first-order model applied per double-difference row; it does
+        // not yet account for DD cross-correlation through the shared pivot.
+        let elevation_deg = match self.attitude() {
+            Some((elev_deg, azim_deg)) => {
+                contribution.elevation_deg = elev_deg;
+                contribution.azimuth_deg = azim_deg;
+                Some(elev_deg)
+            },
+            None => None,
+        };
+
+        if !two_rows && cfg.method == Method::PPP {
+            // row #1 carries phase in this case
+            vec.sigma_1 = cfg.solver.phase_sigma_m(elevation_deg);
+        } else {
+            vec.sigma_1 = cfg.solver.code_sigma_m(elevation_deg);
+        }
+
+        if two_rows && cfg.method == Method::PPP {
+            vec.sigma_2 = cfg.solver.phase_sigma_m(elevation_deg);
+        }
+
         Ok(vec)
     }
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -9,7 +9,7 @@ mod solver;
 
 pub use crate::{
     carrier::Signal,
-    cfg::solver::SolverOpts,
+    cfg::solver::{SolverOpts, Weighting},
     cfg::{method::Method, modeling::Modeling},
     prelude::TimeScale,
 };

--- a/src/cfg/solver.rs
+++ b/src/cfg/solver.rs
@@ -3,6 +3,16 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// Base (zenith referenced) pseudo-range standard deviation, in meters.
+const DEFAULT_CODE_SIGMA_M: f64 = 1.0;
+
+/// Base (zenith referenced) phase-range standard deviation, in meters.
+const DEFAULT_PHASE_SIGMA_M: f64 = 3.0E-3;
+
+/// Lower bound applied to sin(elevation) when forming the elevation weighting,
+/// to avoid the singularity at the horizon (caps the model around 2.9°).
+const MIN_SIN_ELEV: f64 = 0.05;
+
 const fn default_max_gdop() -> f64 {
     5.0
 }
@@ -13,6 +23,31 @@ const fn default_postfit_denoising() -> f64 {
 
 const fn default_open_loop() -> bool {
     false
+}
+
+const fn default_weighting() -> Weighting {
+    Weighting::None
+}
+
+/// [Weighting] strategy used to build the measurement weight matrix `W`,
+/// where each measurement contributes `1/σ²` on the diagonal.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Weighting {
+    /// Uniform weighting: every measurement is trusted equally (`W = I`).
+    /// This reproduces an ordinary (unweighted) least-squares solution and is
+    /// the current default, preserving legacy behavior.
+    #[cfg_attr(feature = "serde", serde(alias = "none", alias = "None"))]
+    #[default]
+    None,
+
+    /// Elevation dependent weighting: `σ²(E) = σ₀² / sin²(E)`.
+    /// Low-elevation measurements are down-weighted, as they suffer larger
+    /// tropospheric residuals, multipath and antenna gain roll-off. This
+    /// mirrors the tropospheric mapping function and helps most when the
+    /// measurement pool is of heterogeneous quality.
+    #[cfg_attr(feature = "serde", serde(alias = "elevation", alias = "Elevation"))]
+    Elevation,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -32,6 +67,10 @@ pub struct SolverOpts {
     /// 1000 for x1000 improvement attempt.
     #[cfg_attr(feature = "serde", serde(default = "default_postfit_denoising"))]
     pub postfit_denoising: f64,
+
+    /// Measurement [Weighting] model used to build the weight matrix.
+    #[cfg_attr(feature = "serde", serde(default = "default_weighting"))]
+    pub weighting: Weighting,
 }
 
 impl Default for SolverOpts {
@@ -40,6 +79,7 @@ impl Default for SolverOpts {
             max_gdop: default_max_gdop(),
             open_loop: default_open_loop(),
             postfit_denoising: default_postfit_denoising(),
+            weighting: default_weighting(),
         }
     }
 }
@@ -51,6 +91,93 @@ impl SolverOpts {
             max_gdop: 3.0,
             open_loop: default_open_loop(),
             postfit_denoising: default_postfit_denoising(),
+            weighting: default_weighting(),
         }
+    }
+
+    /// Returns the pseudo-range standard deviation (m) at `elevation_deg`,
+    /// under the configured [Weighting] model.
+    pub(crate) fn code_sigma_m(&self, elevation_deg: Option<f64>) -> f64 {
+        self.measurement_sigma_m(DEFAULT_CODE_SIGMA_M, elevation_deg)
+    }
+
+    /// Returns the phase-range standard deviation (m) at `elevation_deg`,
+    /// under the configured [Weighting] model.
+    pub(crate) fn phase_sigma_m(&self, elevation_deg: Option<f64>) -> f64 {
+        self.measurement_sigma_m(DEFAULT_PHASE_SIGMA_M, elevation_deg)
+    }
+
+    /// Returns the measurement standard deviation (m) for an observation of
+    /// base (zenith) deviation `base_sigma_m` seen at `elevation_deg`, under
+    /// the configured [Weighting] model. [Weighting::None] yields a unit
+    /// deviation (uniform weighting); when elevation is unknown under an
+    /// elevation model, the base deviation is returned.
+    fn measurement_sigma_m(&self, base_sigma_m: f64, elevation_deg: Option<f64>) -> f64 {
+        match self.weighting {
+            Weighting::None => 1.0,
+            Weighting::Elevation => match elevation_deg {
+                Some(elev_deg) => {
+                    let sin_elev = elev_deg.to_radians().sin().max(MIN_SIN_ELEV);
+                    base_sigma_m / sin_elev
+                },
+                None => base_sigma_m,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{DEFAULT_CODE_SIGMA_M, MIN_SIN_ELEV, SolverOpts, Weighting};
+
+    #[test]
+    fn elevation_weighting() {
+        let opts = SolverOpts {
+            weighting: Weighting::Elevation,
+            ..Default::default()
+        };
+
+        // zenith: deviation equals the base value
+        let zenith = opts.code_sigma_m(Some(90.0));
+        assert!((zenith - DEFAULT_CODE_SIGMA_M).abs() < 1.0E-9);
+
+        // 30°: sin(30°)=0.5 -> deviation doubles
+        let e30 = opts.code_sigma_m(Some(30.0));
+        assert!((e30 - DEFAULT_CODE_SIGMA_M / 0.5).abs() < 1.0E-9);
+
+        // low elevation is down-weighted (larger sigma than at zenith)
+        assert!(opts.code_sigma_m(Some(5.0)) > zenith);
+
+        // phase is far more precise than code
+        assert!(opts.phase_sigma_m(Some(90.0)) < opts.code_sigma_m(Some(90.0)));
+
+        // unknown elevation falls back to the base deviation
+        assert!((opts.code_sigma_m(None) - DEFAULT_CODE_SIGMA_M).abs() < 1.0E-9);
+    }
+
+    #[test]
+    fn uniform_weighting() {
+        let opts = SolverOpts {
+            weighting: Weighting::None,
+            ..Default::default()
+        };
+
+        // uniform weighting => unit deviation regardless of elevation
+        assert_eq!(opts.code_sigma_m(Some(10.0)), 1.0);
+        assert_eq!(opts.phase_sigma_m(Some(90.0)), 1.0);
+        assert_eq!(opts.code_sigma_m(None), 1.0);
+    }
+
+    #[test]
+    fn horizon_guard() {
+        let opts = SolverOpts {
+            weighting: Weighting::Elevation,
+            ..Default::default()
+        };
+
+        // sigma stays finite at/below the horizon thanks to MIN_SIN_ELEV
+        let sigma = opts.code_sigma_m(Some(0.0));
+        assert!(sigma.is_finite());
+        assert!((sigma - DEFAULT_CODE_SIGMA_M / MIN_SIN_ELEV).abs() < 1.0E-9);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub mod prelude {
         },
         candidate::{Candidate, Observation},
         carrier::{Carrier, Signal},
-        cfg::{Config, Method},
+        cfg::{Config, Method, Weighting},
         constants::SPEED_OF_LIGHT_M_S,
         ephemeris::{Ephemeris, EphemerisSource},
         error::Error,

--- a/src/navigation/mod.rs
+++ b/src/navigation/mod.rs
@@ -414,7 +414,7 @@ impl Navigation {
             let vec = vec.unwrap();
 
             self.y_k_vec.push(vec.row_1);
-            self.w_k_vec.push(1.0); // TODO improve model
+            self.w_k_vec.push(vec.sigma_1.powi(2));
             self.indexes.push(i);
             self.sv.push(contrib);
         }
@@ -578,7 +578,7 @@ impl Navigation {
 
                 if let Some(vec) = vec {
                     self.y_k_vec.push(vec.row_1);
-                    self.w_k_vec.push(1.0); // TODO improve model
+                    self.w_k_vec.push(vec.sigma_1.powi(2));
                     true
                 } else {
                     false
@@ -676,7 +676,7 @@ impl Navigation {
 
             if let Some(vec) = vec {
                 self.y_k_vec.push(vec.row_1);
-                self.w_k_vec.push(1.0); // TODO improve model
+                self.w_k_vec.push(vec.sigma_1.powi(2));
                 self.indexes.push(i);
                 self.sv.push(contrib);
             } else {

--- a/src/navigation/ppp_ar/mod.rs
+++ b/src/navigation/ppp_ar/mod.rs
@@ -246,8 +246,8 @@ impl Solver {
                 Ok(vec) => {
                     self.y_k_vec.push(vec.row_1);
                     self.y_k_vec.push(vec.row_2);
-                    self.w_k_vec.push(1.0); // TODO: improve model
-                    self.w_k_vec.push(1.0); // TODO: improve model
+                    self.w_k_vec.push(vec.sigma_1.powi(2));
+                    self.w_k_vec.push(vec.sigma_2.powi(2));
                     self.indexes.push(i);
                     self.sv.push(contrib);
                 },
@@ -376,8 +376,8 @@ impl Solver {
                     Ok(vec) => {
                         self.y_k_vec.push(vec.row_1);
                         self.y_k_vec.push(vec.row_2);
-                        self.w_k_vec.push(1.0); // TODO improve model
-                        self.w_k_vec.push(1.0); // TODO improve model
+                        self.w_k_vec.push(vec.sigma_1.powi(2));
+                        self.w_k_vec.push(vec.sigma_2.powi(2));
                         true
                     },
                     Err(e) => {
@@ -506,7 +506,8 @@ impl Solver {
                 Ok(vec) => {
                     self.y_k_vec.push(vec.row_1);
                     self.y_k_vec.push(vec.row_2);
-                    self.w_k_vec.push(1.0); // TODO
+                    self.w_k_vec.push(vec.sigma_1.powi(2));
+                    self.w_k_vec.push(vec.sigma_2.powi(2));
                     self.sv.push(contrib);
                     self.indexes.push(i);
                 },
@@ -539,7 +540,7 @@ impl Solver {
         self.w_k.resize_mut(y_len, y_len, 0.0);
 
         for i in 0..y_len {
-            self.w_k[(i, i)] = 1.0; // TODO: improve model
+            self.w_k[(i, i)] = 1.0 / self.w_k_vec[i];
         }
 
         // form G

--- a/src/navigation/vector.rs
+++ b/src/navigation/vector.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone)]
 pub struct VectorContribution {
     /// Row #1 contribution
     pub row_1: f64,
@@ -6,6 +6,22 @@ pub struct VectorContribution {
     /// Row #2 contribution
     pub row_2: f64,
 
-    /// sigma
-    pub sigma: f64,
+    /// Measurement standard deviation (m) for row #1.
+    pub sigma_1: f64,
+
+    /// Measurement standard deviation (m) for row #2.
+    pub sigma_2: f64,
+}
+
+impl Default for VectorContribution {
+    fn default() -> Self {
+        // Unit deviations keep the weight matrix at identity (uniform
+        // weighting) until a model fills them in.
+        Self {
+            row_1: 0.0,
+            row_2: 0.0,
+            sigma_1: 1.0,
+            sigma_2: 1.0,
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements the long-standing measurement-weighting TODO (the `w_k = 1.0 // TODO improve model` stubs), replacing uniform measurement weights with a configurable, elevation-dependent model.

## Model

A new `Weighting` enum on `SolverOpts`:

- **`Weighting::None`** — uniform weighting (`W = I`), i.e. the current behavior. **This is the default**, so existing solutions are unchanged.
- **`Weighting::Elevation`** — `σ²(E) = σ₀² / sin²(E)`, with separate base deviations for code (1.0 m) and phase (3 mm) and a horizon guard. Low-elevation measurements are down-weighted, mirroring the tropospheric mapping function.

Per-measurement deviations are computed in the candidate contributions (where elevation is already resolved) and carried on `VectorContribution.sigma_1/sigma_2`, then squared into the diagonal weight matrix at every live solver path: the SPP/CPP/PPP least-squares (`navigation/mod.rs`) and the PPP-AR / RTK filter (`navigation/ppp_ar/mod.rs`).

## Also in this PR

- **Bug fix:** the PPP-AR `kf_run` block pushed two measurement rows (code + phase) but only one weight, then rebuilt `W` as the identity. Both are corrected, so `W` is now actually formed from the per-row variances.

## Testing

- New unit tests for the weighting model (zenith → base σ, 30° → 2σ, horizon guard, `None` → unit weight).
- Full suite green with the default (`None`): **52 passed, 0 failed**.

## Open questions for review

A few decisions I'd value your steer on:

1. **Default on vs off.** I kept it opt-in (`None`) to be non-breaking. With `Elevation` on, 9 code-solution survey tests fail — but only by hand-fit-threshold margins (e.g. SPP Y `39.356 m` vs a `39.3 m` bound), and *slightly worse*, because those datasets are clean and systematic-bias-dominated (CPP sits at a steady ~31 m X/Y every epoch). Weighting's benefit shows on heterogeneous-quality pools, not these. If you'd prefer it on by default, the thresholds in `src/tests/mod.rs` need re-tuning — happy to do that.
2. **RTK double differences.** Weighting is applied per-DD-row using the satellite's own elevation as a first-order proxy. It does **not** yet model DD cross-correlation through the shared pivot (which needs a full covariance `W`, not a diagonal). Flagged in-code.
3. **Base σ₀ values** (code 1.0 m / phase 3 mm) are module constants. Happy to promote them to `SolverOpts` if you'd like them user-tunable.
4. **SNR weighting** is deferred (the `snr_dbhz` field is often a placeholder); the model falls back cleanly when elevation is unknown.

## Note

`src/navigation/ppp.rs` appears to be dead code — it is never declared as a module (`navigation/mod.rs` has no `mod ppp;`), so it doesn't compile, and its weight stubs were intentionally left untouched. It still references the now-removed `VectorContribution::sigma` field, so it would need cleanup (or deletion) before being reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
